### PR TITLE
add withOptions api

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,28 @@ To configure scanning, use the AxeBuilder class chainable apis.
                     .DisableRules("color-contrast")
                     .Analyze();
     ``` 
--   AxeBuilder.Options - Run options that is to be passed to axe scan api. This should be a json string of format - https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter. This cannot be used with WithRules /WithTags /DisableRules apis.
+-   AxeBuilder.Options - This method is deprecated. Use WithOptions / WithRules / WithTags / DisableRules apis instead. 
+    
+    Run options that is to be passed to axe scan api. This should be a json string of format - https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter. This cannot be used with WithRules /WithTags /DisableRules apis.
     ```csharp
     var axeBuilder = new AxeBuilder(webDriver);
     axeBuilder.Options = "{\"runOnly\": {\"type\": \"tag\", \"values\": [\"wcag2a\"]}, \"restoreScroll\": true}"
     var results = axeBuilder.Analyze();
+    ``` 
+- AxeBuilder.WithOptions - Run options that is to be passed to axe scan api. This will override the value set by WithRules, WithTags & DisableRules apis.
+    ```csharp
+    var results = new AxeBuilder(webDriver)
+                    .WithOptions(new AxeRunOptions()
+                    {
+                        RunOnly = new RunOnlyOptions
+                        {
+                            Type = "rule",
+                            Values = new List<string> { "duplicate-id", "color-contrast" }
+                        },
+                        
+                        RestoreScroll = true
+                    })
+                    .Analyze();
     ``` 
 - AxeBuilder.AxeBuilder(webDriver, axeBuilderOptions) - This api allows you to run scanning on axe version that is not packaged with this library.
     ```csharp

--- a/Selenium.Axe/Selenium.Axe.Test/AxeBuilderTest.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/AxeBuilderTest.cs
@@ -297,6 +297,25 @@ namespace Selenium.Axe.Test
             VerifyExceptionThrown<ArgumentException>(() => builder.Exclude(values));
         }
 
+        [TestMethod]
+        public void ShouldThrowIfDeprecatedOptionsIsUsedWithNewOptionsApis()
+        {
+            SetupVerifiableAxeInjectionCall();
+
+            var builder = new AxeBuilder(webDriverMock.Object);
+#pragma warning disable CS0618
+            builder.Options = "{xpath:true}";
+#pragma warning restore CS0618
+
+            VerifyExceptionThrown<InvalidOperationException>(() => builder.WithRules("rule-1"));
+            VerifyExceptionThrown<InvalidOperationException>(() => builder.DisableRules("rule-1"));
+            VerifyExceptionThrown<InvalidOperationException>(() => builder.WithTags("tag1"));
+            VerifyExceptionThrown<InvalidOperationException>(() => builder.WithOptions(new AxeRunOptions() { Iframes = true }));
+
+
+        }
+
+
         private void VerifyExceptionThrown<T>(Action action) where T : Exception
         {
             action.Should().Throw<T>();

--- a/Selenium.Axe/Selenium.Axe.Test/AxeBuilderTest.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/AxeBuilderTest.cs
@@ -240,23 +240,19 @@ namespace Selenium.Axe.Test
         [TestMethod]
         public void ShouldPassRunOptions()
         {
-            var initialRunOptions = new AxeRunOptions()
-            {
-                Iframes = true,
-            };
-
-            var expectedRunOptions = SerializeObject(new AxeRunOptions()
+            var runOptions = new AxeRunOptions()
             {
                 Iframes = true,
                 Rules = new Dictionary<string, RuleOptions>() { { "rule1", new RuleOptions() { Enabled = false } } }
-            });
+            };
+
+            var expectedRunOptions = SerializeObject(runOptions);
 
             SetupVerifiableAxeInjectionCall();
             SetupVerifiableScanCall(null, expectedRunOptions);
 
             var builder = new AxeBuilder(webDriverMock.Object)
-                .WithOptions(initialRunOptions)
-                .DisableRules("rule1");
+                .WithOptions(runOptions);
 
             var result = builder.Analyze();
 

--- a/Selenium.Axe/Selenium.Axe.Test/AxeRunOptionsTest.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/AxeRunOptionsTest.cs
@@ -27,7 +27,9 @@ namespace Selenium.Axe.Test
 
             var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
             var expectedObject = "{\"runOnly\":{\"type\":\"tag\",\"values\":[\"tag1\",\"tag2\"]}}";
+
             serializedObject.Should().Be(expectedObject);
+            JsonConvert.DeserializeObject<AxeRunOptions>(expectedObject).Should().BeEquivalentTo(options);
         }
 
         [TestMethod]
@@ -42,11 +44,49 @@ namespace Selenium.Axe.Test
                     {"rule3WithoutOptionsData", new RuleOptions(){ } },
                 }
             };
+            var expectedObject = "{\"rules\":{\"enabledRule\":{\"enabled\":true},\"disabledRule\":{\"enabled\":false},\"rule3WithoutOptionsData\":{}}}";
 
             var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
 
-            var expectedObject = "{\"rules\":{\"enabledRule\":{\"enabled\":true},\"disabledRule\":{\"enabled\":false},\"rule3WithoutOptionsData\":{}}}";
+
             serializedObject.Should().Be(expectedObject);
+            JsonConvert.DeserializeObject<AxeRunOptions>(expectedObject).Should().BeEquivalentTo(options);
+        }
+
+        [TestMethod]
+        public void ShouldSerializeLiteralTypes()
+        {
+            var options = new AxeRunOptions()
+            {
+                AbsolutePaths = true,
+                FrameWaitTimeInMilliSec = 10,
+                Iframes = true,
+                RestoreScroll = true,
+            };
+            var expectedObject = "{\"absolutePaths\":true,\"iframes\":true,\"restoreScroll\":true,\"frameWaitTime\":10}";
+
+            var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
+
+
+            serializedObject.Should().Be(expectedObject);
+            JsonConvert.DeserializeObject<AxeRunOptions>(expectedObject).Should().BeEquivalentTo(options);
+
+        }
+
+        [TestMethod]
+        public void ShouldSerializeResultTypes()
+        {
+            var options = new AxeRunOptions()
+            {
+                ResultTypes = new HashSet<ResultType>() { ResultType.Inapplicable, ResultType.Incomplete, ResultType.Passes, ResultType.Violations }
+            };
+
+            var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
+
+            var expectedObject = "{\"resultTypes\":[\"inapplicable\",\"incomplete\",\"passes\",\"violations\"]}";
+
+            serializedObject.Should().Be(expectedObject);
+            JsonConvert.DeserializeObject<AxeRunOptions>(expectedObject).Should().BeEquivalentTo(options);
         }
     }
 }

--- a/Selenium.Axe/Selenium.Axe.Test/AxeRunOptionsTest.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/AxeRunOptionsTest.cs
@@ -48,7 +48,6 @@ namespace Selenium.Axe.Test
 
             var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
 
-
             serializedObject.Should().Be(expectedObject);
             JsonConvert.DeserializeObject<AxeRunOptions>(expectedObject).Should().BeEquivalentTo(options);
         }
@@ -59,14 +58,13 @@ namespace Selenium.Axe.Test
             var options = new AxeRunOptions()
             {
                 AbsolutePaths = true,
-                FrameWaitTimeInMilliSec = 10,
+                FrameWaitTimeInMilliseconds = 10,
                 Iframes = true,
                 RestoreScroll = true,
             };
             var expectedObject = "{\"absolutePaths\":true,\"iframes\":true,\"restoreScroll\":true,\"frameWaitTime\":10}";
 
             var serializedObject = JsonConvert.SerializeObject(options, serializerSettings);
-
 
             serializedObject.Should().Be(expectedObject);
             JsonConvert.DeserializeObject<AxeRunOptions>(expectedObject).Should().BeEquivalentTo(options);

--- a/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
@@ -42,12 +42,16 @@ namespace Selenium.Axe.Test
             this.InitDriver(browser);
             LoadTestPage();
 
-            var builder = new AxeBuilder(_webDriver).WithTags("wcag2a", "wcag2aa").DisableRules("color-contrast");
+            var builder = new AxeBuilder(_webDriver)
+                .WithOptions(new AxeRunOptions() { XPath = true })
+                .WithTags("wcag2a", "wcag2aa")
+                .DisableRules("color-contrast");
 
             var results = builder.Analyze();
             results.Violations.FirstOrDefault(v => v.Id == "color-contrast").Should().BeNull();
             results.Violations.FirstOrDefault(v => !v.Tags.Contains("wcag2a") && !v.Tags.Contains("wcag2aa")).Should().BeNull();
             results.Violations.Should().HaveCount(2);
+            results.Violations.First().Nodes.First().XPath.Should().NotBeNullOrEmpty();
         }
 
         [TestMethod]

--- a/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
@@ -33,7 +33,6 @@ namespace Selenium.Axe.Test
             _webDriver?.Dispose();
         }
 
-
         [TestMethod]
         [DataRow("Chrome")]
         [DataRow("Firefox")]
@@ -67,7 +66,6 @@ namespace Selenium.Axe.Test
             AxeResult results = _webDriver.Analyze(mainElement);
             results.Violations.Should().HaveCount(3);
         }
-
 
         private void LoadTestPage()
         {

--- a/Selenium.Axe/Selenium.Axe/AxeBuilder.cs
+++ b/Selenium.Axe/Selenium.Axe/AxeBuilder.cs
@@ -48,9 +48,7 @@ namespace Selenium.Axe
         {
             ValidateNotNullParameter(runOptions, nameof(runOptions));
 
-#pragma warning disable CS0618
-            Options = null;
-#pragma warning restore CS0618
+            ThrowIfDeprecatedOptionsSet();
 
             this.runOptions = runOptions;
 
@@ -67,9 +65,7 @@ namespace Selenium.Axe
         {
             ValidateParameters(tags, nameof(tags));
 
-#pragma warning disable CS0618
-            Options = null;
-#pragma warning restore CS0618
+            ThrowIfDeprecatedOptionsSet();
 
             runOptions.RunOnly = new RunOnlyOptions
             {
@@ -89,9 +85,7 @@ namespace Selenium.Axe
         {
             ValidateParameters(rules, nameof(rules));
 
-#pragma warning disable CS0618
-            Options = null;
-#pragma warning restore CS0618
+            ThrowIfDeprecatedOptionsSet();
 
             runOptions.RunOnly = new RunOnlyOptions
             {
@@ -112,9 +106,7 @@ namespace Selenium.Axe
         {
             ValidateParameters(rules, nameof(rules));
 
-#pragma warning disable CS0618
-            Options = null;
-#pragma warning restore CS0618
+            ThrowIfDeprecatedOptionsSet();
 
             var rulesMap = new Dictionary<string, RuleOptions>();
             foreach (var rule in rules)
@@ -199,7 +191,7 @@ namespace Selenium.Axe
             string contextToBeSent = runContextHasData ? JsonConvert.SerializeObject(runContext, JsonSerializerSettings) : null;
 
 #pragma warning disable CS0618
-            string runOptionsToBeSent = string.IsNullOrWhiteSpace(Options) ? JsonConvert.SerializeObject(runOptions, JsonSerializerSettings) : Options;
+            string runOptionsToBeSent = Options == "{}" ? JsonConvert.SerializeObject(runOptions, JsonSerializerSettings) : Options;
 #pragma warning restore CS0618
 
 
@@ -232,6 +224,14 @@ namespace Selenium.Axe
             if (parameterValue == null)
             {
                 throw new ArgumentNullException(parameterName);
+            }
+        }
+
+        private void ThrowIfDeprecatedOptionsSet()
+        {
+            if (Options != "{}")
+            {
+                throw new InvalidOperationException("Deprecated Options api shouldn't be used with the new apis - WithOptions/WithRules/WithTags or DisableRules");
             }
         }
     }

--- a/Selenium.Axe/Selenium.Axe/AxeBuilder.cs
+++ b/Selenium.Axe/Selenium.Axe/AxeBuilder.cs
@@ -48,6 +48,10 @@ namespace Selenium.Axe
         {
             ValidateNotNullParameter(runOptions, nameof(runOptions));
 
+#pragma warning disable CS0618
+            Options = null;
+#pragma warning restore CS0618
+
             this.runOptions = runOptions;
 
             return this;

--- a/Selenium.Axe/Selenium.Axe/AxeResultNode.cs
+++ b/Selenium.Axe/Selenium.Axe/AxeResultNode.cs
@@ -6,6 +6,7 @@ namespace Selenium.Axe
     public class AxeResultNode
     {
         public List<string> Target { get; set; }
+        public List<string> XPath { get; set; }
         public string Html { get; set; }
         public string Impact { get; set; }
         public AxeResultCheck[] Any { get; set; }

--- a/Selenium.Axe/Selenium.Axe/AxeRunOptions.cs
+++ b/Selenium.Axe/Selenium.Axe/AxeRunOptions.cs
@@ -107,6 +107,6 @@ namespace Selenium.Axe
         /// How long (in milliseconds) axe waits for a response from embedded frames before timing out
         /// </summary>
         [JsonProperty("frameWaitTime")]
-        public int? FrameWaitTimeInMilliSec { get; set; }
+        public int? FrameWaitTimeInMilliseconds { get; set; }
     }
 }

--- a/Selenium.Axe/Selenium.Axe/AxeRunOptions.cs
+++ b/Selenium.Axe/Selenium.Axe/AxeRunOptions.cs
@@ -1,5 +1,7 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Selenium.Axe
 {
@@ -36,8 +38,22 @@ namespace Selenium.Axe
         public bool? Enabled { get; set; }
     }
 
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum ResultType
+    {
+        [EnumMember(Value = "violations")]
+        Violations,
+        [EnumMember(Value = "incomplete")]
+        Incomplete,
+        [EnumMember(Value = "inapplicable")]
+        Inapplicable,
+        [EnumMember(Value = "passes")]
+        Passes
+    }
+
     /// <summary>
-    /// Run configuration data that is passed to axe for scanning the web page
+    /// Run configuration data that is passed to axe for scanning the web page.
+    /// Refer https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter for more information
     /// </summary>
     [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class AxeRunOptions
@@ -54,5 +70,43 @@ namespace Selenium.Axe
         [JsonProperty("rules")]
         public Dictionary<string, RuleOptions> Rules { get; set; }
 
+        /// <summary>
+        /// Limit which result types are processed and aggregated. An approach you can take to reducing the time is use the resultTypes option. 
+        /// For eg, when set to [ResultTypes.Violations], scan results will only have the full details of the violations array and 
+        /// will only have one instance of each of the inapplicable, incomplete and pass arrays for each rule that has at least one of those entries. 
+        /// This will reduce the amount of computation that axe-core does for the unique selectors.
+        /// </summary>
+        [JsonProperty("resultTypes")]
+        public HashSet<ResultType> ResultTypes { get; set; }
+
+        /// <summary>
+        /// Returns xpath selectors for elements
+        /// </summary>
+        [JsonProperty("xpath")]
+        public bool? XPath { get; set; }
+
+        /// <summary>
+        /// Use absolute paths when creating element selectors
+        /// </summary>
+        [JsonProperty("absolutePaths")]
+        public bool? AbsolutePaths { get; set; }
+
+        /// <summary>
+        /// Tell axe to run inside iframes
+        /// </summary>
+        [JsonProperty("iframes")]
+        public bool? Iframes { get; set; }
+
+        /// <summary>
+        /// Scrolls elements back to the state before scan started
+        /// </summary>
+        [JsonProperty("restoreScroll")]
+        public bool? RestoreScroll { get; set; }
+
+        /// <summary>
+        /// How long (in milliseconds) axe waits for a response from embedded frames before timing out
+        /// </summary>
+        [JsonProperty("frameWaitTime")]
+        public int? FrameWaitTimeInMilliSec { get; set; }
     }
 }


### PR DESCRIPTION
1.) We are deprecating AxeBuilder.Options api.
2.) Added WithOptions api that is more strongly typed instead of using a JSON string. Exposed the properties under options that we expect to be used from https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter