### PR TITLE
Add a WithOutputFile option to AxeBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ To configure scanning, use the AxeBuilder class chainable apis.
                     })
                     .Analyze();
     ``` 
+- AxeBuilder.WithOutputFile - Causes Analyze() to export its results a JSON file, in addition to being returned as an AxeResult object as usual.
+    ```csharp
+    var results = new AxeBuilder(webDriver)
+                    .WithOutputFile(@"./path/to/axe-results.json")
+                    .Analyze();
+    ```
 - AxeBuilder.AxeBuilder(webDriver, axeBuilderOptions) - This api allows you to run scanning on axe version that is not packaged with this library.
     ```csharp
     var axeBuilderOptions = new AxeBuilderOptions

--- a/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
@@ -85,26 +85,23 @@ namespace Selenium.Axe.Test
             {
                 case "CHROME":
                     var chromeDriverDirectory = Environment.GetEnvironmentVariable("ChromeWebDriver") ?? Environment.CurrentDirectory;
-                    ChromeOptions chromeOptions = new ChromeOptions
+                    ChromeOptions options = new ChromeOptions
                     {
                         UnhandledPromptBehavior = UnhandledPromptBehavior.Accept,
                     };
-                    chromeOptions.AddArgument("no-sandbox");
-                    chromeOptions.AddArgument("--log-level=3");
-                    chromeOptions.AddArgument("--silent");
-                    chromeOptions.AddArgument("--headless");
+                    options.AddArgument("no-sandbox");
+                    options.AddArgument("--log-level=3");
+                    options.AddArgument("--silent");
 
                     ChromeDriverService service = ChromeDriverService.CreateDefaultService(chromeDriverDirectory);
                     service.SuppressInitialDiagnosticInformation = true;
-                    _webDriver = new ChromeDriver(chromeDriverDirectory, chromeOptions);
+                    _webDriver = new ChromeDriver(chromeDriverDirectory, options);
 
                     break;
 
                 case "FIREFOX":
                     var geckoDriverDirectory = Environment.GetEnvironmentVariable("GeckoWebDriver") ?? Environment.CurrentDirectory;
-                    FirefoxOptions firefoxOptions = new FirefoxOptions();
-                    firefoxOptions.AddArgument("--headless");
-                    _webDriver = new FirefoxDriver(geckoDriverDirectory, firefoxOptions);
+                    _webDriver = new FirefoxDriver(geckoDriverDirectory);
                     break;
 
                 default:

--- a/Selenium.Axe/Selenium.Axe/AxeBuilder.cs
+++ b/Selenium.Axe/Selenium.Axe/AxeBuilder.cs
@@ -19,6 +19,7 @@ namespace Selenium.Axe
         private readonly AxeRunContext runContext = new AxeRunContext();
         private AxeRunOptions runOptions = new AxeRunOptions();
         private string outputFilePath = null;
+
         private static readonly AxeBuilderOptions DefaultOptions = new AxeBuilderOptions { ScriptProvider = new EmbeddedResourceAxeProvider() };
         private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
         {

--- a/Selenium.Axe/Selenium.Axe/AxeBuilder.cs
+++ b/Selenium.Axe/Selenium.Axe/AxeBuilder.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OpenQA.Selenium;
 using System;
@@ -219,9 +219,15 @@ namespace Selenium.Axe
         /// <param name="args">args to be passed to scan function (context, options)</param>
         private AxeResult Execute(params object[] args)
         {
+            string stringifiedResult = (string)((IJavaScriptExecutor)_webDriver).ExecuteAsyncScript(EmbeddedResourceProvider.ReadEmbeddedFile("scan.js"), args);
+
             if (outputFilePath != null) {
-                File.WriteAllText(outputFilePath, rawAxeResult, Encoding.UTF8);
+                File.WriteAllText(outputFilePath, stringifiedResult, Encoding.UTF8);
             }
+
+            var jObject = JObject.Parse(stringifiedResult);
+            return new AxeResult(jObject);
+
         }
 
         private static void ValidateParameters(string[] parameterValue, string parameterName)


### PR DESCRIPTION
Some of the users our team has been interacting with have expressed interest in post-processing the scan results into other types of logging/reporting formats using existing tools that work with axe result JSON (eg, [axe-sarif-converter](https://github.com/microsoft/axe-sarif-converter)).

This PR enables compatibility with those tools by enabling exporting the results as-is (in the exact output format from axe-core) to a separate JSON file.

I've verified that the output file produced by the integration tests is consumable from axe-sarif-converter.

Usage looks like:

```csharp
new AxeBuilder(webDriver)
    .WithOutputFile(@"./path/to/output-file.json")
    .Analyze();
```

Since this would be a new feature, we'd want to release it under a new minor version number.