### PR TITLE
Update README to address feedback from user studies

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Runs an axe accessibility scan of the entire page using all previously chained o
 ### `AxeBuilder.Analyze(IWebElement element)`
 
 ```csharp
-var elementToTest = webDriver.FindElement(By.Id("nav-bar"));
+IWebElement elementToTest = webDriver.FindElement(By.Id("nav-bar"));
 AxeResult axeResult = new AxeBuilder(webDriver)
     .Analyze(elementToTest);
 ```
@@ -82,7 +82,7 @@ Not compatible with `AxeBuilder.Include` or `AxeBuilder.Exclude`; the element pa
 ### `AxeBuilder.Include(params string[] cssSelectorPath)`
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Include(".class-of-element-under-test")
     .Analyze();
 ```
@@ -94,7 +94,7 @@ Scopes future `Analyze()` calls to include *only* the element(s) matching the gi
 `Include` may be combined with `Exclude` to scan a tree of elements but omit some children of that tree. For example:
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Include("#element-under-test")
     .Exclude("#element-under-test div.child-class-with-known-issues")
     .Analyze();
@@ -106,17 +106,17 @@ If you pass multiple CSS selectors to a single invocation of `Include`, this wil
 
 ```csharp
 // This is correct
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Include("#id-of-iframe", "#id-of-child-element-inside-iframe")
     .Analyze();
 
 // This is wrong!
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Include("#first-element", "#second-element")
     .Analyze();
 
 // If you want to include multiple elements, use multiple .Include() calls instead
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Include("#first-element")
     .Include("#second-element")
     .Analyze();
@@ -125,7 +125,7 @@ var results = new AxeBuilder(webDriver)
 ### `AxeBuilder.Exclude(params string[] cssSelectorPath)`
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Exclude(".class-of-element-with-known-issues")
     .Analyze();
 ```
@@ -137,7 +137,7 @@ Scopes future `Analyze()` calls to exclude the element(s) matching the given CSS
 `Exclude` may be combined with `Include` to scan a tree of elements but omit some children of that tree. For example:
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Include("#element-under-test")
     .Exclude("#element-under-test div.child-class-with-known-issues")
     .Analyze();
@@ -149,17 +149,17 @@ If you pass multiple CSS selectors to a single invocation of `Exclude`, this wil
 
 ```csharp
 // This is correct
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Exclude("#id-of-iframe", "#id-of-child-element-inside-iframe")
     .Analyze();
 
 // This is wrong!
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Exclude("#first-element", "#second-element")
     .Analyze();
 
 // If you want to exclude multiple elements, use multiple .Exclude() calls instead
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .Exclude("#first-element")
     .Exclude("#second-element")
     .Analyze();
@@ -168,7 +168,7 @@ var results = new AxeBuilder(webDriver)
 ### `AxeBuilder.WithRules(params string[] axeRuleIds)`
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .WithRules("color-contrast", "duplicate-id")
     .Analyze();
 ```
@@ -184,7 +184,7 @@ For a list of the available axe rules, see https://dequeuniversity.com/rules/axe
 ### `AxeBuilder.DisableRules(params string[] axeRuleIds)`
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .DisableRules("color-contrast", "duplicate-id")
     .Analyze();
 ```
@@ -196,7 +196,7 @@ For a list of the available axe rules, see https://dequeuniversity.com/rules/axe
 `DisableRules` is compatible with `WithTags`; you can use this to run all-but-some of the rules for a given set of tags. For example, to run all WCAG 2.0 A rules except for `color-contrast`:
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .WithTags("wcag2a")
     .DisableRules("color-contrast")
     .Analyze();
@@ -215,7 +215,7 @@ A "tag" is a string that may be associated with a given axe rule. See the [axe-c
 `WithTags` is compatible with `DisableRules`; you can use this to run all-but-some of the rules for a given set of tags. For example, to run all WCAG 2.0 A rules except for `color-contrast`:
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .WithTags("wcag2a")
     .DisableRules("color-contrast")
     .Analyze();
@@ -230,7 +230,7 @@ var results = new AxeBuilder(webDriver)
 *Note: in most cases, the simpler `WithRules`, `WithTags`, and `DisableRules` can be used instead.*
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .WithOptions(new AxeRunOptions()
     {
         RunOnly = new RunOnlyOptions
@@ -252,7 +252,7 @@ Causes future calls to `Analyze` to use the specified options when calling `axe.
 ### `AxeBuilder.WithOutputFile(string filePath)`
 
 ```csharp
-var results = new AxeBuilder(webDriver)
+AxeResult axeResult = new AxeBuilder(webDriver)
     .WithOutputFile(@"./path/to/axe-results.json")
     .Analyze();
 ```
@@ -266,11 +266,11 @@ The output format is exactly the same as axe-core would have produced natively, 
 This constructor overload enables certain advanced options not required by most `Selenium.Axe` users. Currently, its only use is to allow you to use a custom `axe-core` implementation, rather than the one that is packaged with this library.
 
 ```csharp
-var axeBuilderOptions = new AxeBuilderOptions
+AxeBuilderOptions axeBuilderOptions = new AxeBuilderOptions
 {
     ScriptProvider = new FileAxeScriptProvider(".\\axe.min.js")
 };
-var results = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
+AxeResult axeResult = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
 ```
 
 ### *Deprecated*: `AxeBuilder.Options`
@@ -278,9 +278,9 @@ var results = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
 *This property is deprecated; instead, use `WithOptions`, `WithRules`, `WithTags`, and `DisableRules`*
 
 ```csharp
-var axeBuilder = new AxeBuilder(webDriver);
+AxeBuilder axeBuilder = new AxeBuilder(webDriver);
 axeBuilder.Options = "{\"runOnly\": {\"type\": \"tag\", \"values\": [\"wcag2a\"]}, \"restoreScroll\": true}"
-var results = axeBuilder.Analyze();
+AxeResult axeResult = axeBuilder.Analyze();
 ```
 
 Sets a JSON string that will be passed as-is to the axe.run `options` parameter.

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ new AxeBuilder(webDriver)
 
 ## Contributing
 
+*Please note that this project is released with a [Contributor Code of Conduct](./CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.*
+
 This project builds against a combination of .NET Standard, .NET Core, and .NET Framework targets.
 
 Prerequisites to build:

--- a/README.md
+++ b/README.md
@@ -1,127 +1,326 @@
-[![Build Status](https://dev.azure.com/AxeDotNet/Axe-Selenium-DotNet/_apis/build/status/SeleniumAxeDotnet?branchName=master)](https://dev.azure.com/AxeDotNet/Axe-Selenium-DotNet/_build/latest?definitionId=4&branchName=master)  
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=TroyWalshProf_SeleniumAxeDotnet&metric=alert_status)](https://sonarcloud.io/dashboard?id=TroyWalshProf_SeleniumAxeDotnet)
+# Selenium.Axe for .NET
 
-# Selenium.Axe
+[![Selenium.Axe NuGet Package](https://img.shields.io/nuget/v/Selenium.Axe)](https://www.nuget.org/packages/Selenium.Axe) [![Build Status](https://dev.azure.com/AxeDotNet/Axe-Selenium-DotNet/_apis/build/status/SeleniumAxeDotnet?branchName=master)](https://dev.azure.com/AxeDotNet/Axe-Selenium-DotNet/_build/latest?definitionId=4&branchName=master) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=TroyWalshProf_SeleniumAxeDotnet&metric=alert_status)](https://sonarcloud.io/dashboard?id=TroyWalshProf_SeleniumAxeDotnet)
 
 Automated web accessibility testing with .NET, C#, and Selenium. Wraps the [axe-core](https://github.com/dequelabs/axe-core) accessibility scanning engine and the [Selenium.WebDriver](https://www.seleniumhq.org/) browser automation framework.
 
-Inspired by [axe-selenium-java](https://github.com/dequelabs/axe-selenium-java) and [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs).
-Forked from [Globant.Selenium.Axe](https://github.com/javnov/axe-selenium-csharp).
+Compatible with .NET Standard 2.0+, .NET Framework 4.5+, and .NET Core 2.0+.
+
+Inspired by [axe-selenium-java](https://github.com/dequelabs/axe-selenium-java) and [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs). Forked from [Globant.Selenium.Axe](https://github.com/javnov/axe-selenium-csharp).
+
+* [Getting Started](#Getting_Started)
+* [`AxeBuilder` Reference](#AxeBuilder_Reference)
+* [Working with `AxeResult` objects](#Working_with_AxeResult_objects)
+* [Contributing](#Contributing)
 
 ## Getting Started
 
-Install via Nuget: 
+Install via NuGet:
+
 ```powershell
 PM> Install-Package Selenium.Axe
+# or, use the Visual Studio "Manage NuGet Packages" UI
 ```
 
 Import this namespace:
+
 ```csharp
 using Selenium.Axe;
 ```
 
-To run axe scan with default configuration, call the extension method ```Analyze``` from your WebDriver object
+To run an axe accessibility scan of a web page with the default configuration, create a new `AxeBuilder` using your Selenium `IWebDriver` object and call `Analyze`:
+
 ```csharp
 IWebDriver webDriver = new ChromeDriver();
-AxeResult results = webDriver.Analyze();
+AxeResult axeResult = new AxeBuilder(webDriver).Analyze();
 ```
 
-To configure scanning, use the AxeBuilder class chainable apis.
--   AxeBuilder.Include - To scope the scanning to dom elements identified by the given selectors. Note that the selectors array uniquely identifies one element in the page. This cannot be used with AxeBuilder.Analyze(element) api.
-    ```csharp
-    var results = new AxeBuilder(webDriver)
-                    .Include("#parent-iframe1", "#element-inside-iframe") // to select #element-inside-iframe under #parent-iframe1
-                    .Include("#element-inside-main-frame1") // to select #element-inside-main-frame1 under the main frame 
-                    .Analyze();
-    ``` 
--   AxeBuilder.Exclude - To exclude dom elements identified by the given selectors from scanning. Note that the selectors array uniquely identifies one element in the page. This cannot be used with AxeBuilder.Analyze(element) api.
-    ```csharp
-    var results = new AxeBuilder(webDriver)
-                    .Exclude("#parent-iframe1", "#element-inside-iframe") // to exclude #element-inside-iframe under #parent-iframe1
-                    .Exclude("#element-inside-main-frame1") // to exclude #element-inside-main-frame1 under the main frame 
-                    .Analyze();
-    ``` 
-- AxeBuilder.Analyze(element) - To run scan on the specified dom element. This cannot be used with Include/Exclude apis.
-    ```csharp
-    var results = new AxeBuilder(webDriver)
-                    .Analyze(webDriver.FindElement(By.Id("nav-bar"))); // Runs scan on the dom element that has id nav-bar.
-    ``` 
+To cause a test to pass or fail based on the scan, use the `Violations` property of the `AxeResult`:
 
--   AxeBuilder.WithTags - To limit analysis to rules that have the mentioned tags. Refer https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter to get the complete list of available tags. This api cannot be used with  WithRules / Options api
-    ```csharp
-    var results = new AxeBuilder(webDriver)
-                    .WithTags("wcag2aa", "best-practice")
-                    .Analyze();
-    ``` 
--   AxeBuilder.WithRules - To limit analysis to specified rules. Refer https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#api-name-axegetrules to get the complete list of available rule IDs. This api cannot be used with  WithTags / Options apis.
-    ```csharp
-    var results = new AxeBuilder(webDriver)
-                    .WithRules("color-contrast", "duplicate-id")
-                    .Analyze();
-    ``` 
--   AxeBuilder.DisableRules - To exclude rules from scanning. Refer https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#api-name-axegetrules to get the complete list of available rule IDs. This api cannot be used with Options api.
-    ```csharp
-    var results = new AxeBuilder(webDriver)
-                    .DisableRules("color-contrast")
-                    .Analyze();
-    ``` 
--   AxeBuilder.Options - This method is deprecated. Use WithOptions / WithRules / WithTags / DisableRules apis instead. 
-    
-    Run options that is to be passed to axe scan api. This should be a json string of format - https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter. This cannot be used with WithRules /WithTags /DisableRules apis.
-    ```csharp
-    var axeBuilder = new AxeBuilder(webDriver);
-    axeBuilder.Options = "{\"runOnly\": {\"type\": \"tag\", \"values\": [\"wcag2a\"]}, \"restoreScroll\": true}"
-    var results = axeBuilder.Analyze();
-    ``` 
-- AxeBuilder.WithOptions - Run options that is to be passed to axe scan api. This will override the value set by WithRules, WithTags & DisableRules apis.
-    ```csharp
-    var results = new AxeBuilder(webDriver)
-                    .WithOptions(new AxeRunOptions()
-                    {
-                        RunOnly = new RunOnlyOptions
-                        {
-                            Type = "rule",
-                            Values = new List<string> { "duplicate-id", "color-contrast" }
-                        },
-                        
-                        RestoreScroll = true
-                    })
-                    .Analyze();
-    ``` 
-- AxeBuilder.WithOutputFile - Causes Analyze() to export its results a JSON file, in addition to being returned as an AxeResult object as usual.
-    ```csharp
-    var results = new AxeBuilder(webDriver)
-                    .WithOutputFile(@"./path/to/axe-results.json")
-                    .Analyze();
-    ```
-- AxeBuilder.AxeBuilder(webDriver, axeBuilderOptions) - This api allows you to run scanning on axe version that is not packaged with this library.
-    ```csharp
-    var axeBuilderOptions = new AxeBuilderOptions
+```csharp
+// We recommend FluentAssertions to get great error messages out of the box
+using FluentAssertions;
+
+axeResult.Violations.Should().BeEmpty();
+```
+
+To configure different scan options, use the chainable methods of the `AxeBuilder` ([reference docs](#AxeBuilder_Options)):
+
+```csharp
+AxeResult axeResult = new AxeBuilder(webDriver)
+    .Exclude(".css-class-of-element-with-known-failures")
+    .WithTags("wcag2a")
+    .Analyze();
+```
+
+For a complete working sample project that uses this library, see [the C# sample in microsoft/axe-pipelines-samples](https://github.com/microsoft/axe-pipelines-samples/tree/master/csharp-selenium-webdriver-sample).
+
+## AxeBuilder reference
+
+### `AxeBuilder.Analyze()`
+
+```csharp
+AxeResult axeResult = new AxeBuilder(webDriver).Analyze();
+```
+
+Runs an axe accessibility scan of the entire page using all previously chained options and returns an `AxeResult` representing the scan results.
+
+### `AxeBuilder.Analyze(IWebElement element)`
+
+```csharp
+var elementToTest = webDriver.FindElement(By.Id("nav-bar"));
+AxeResult axeResult = new AxeBuilder(webDriver)
+    .Analyze(elementToTest);
+```
+
+Runs an axe accessibility scan scoped using all previously chained options to the given Selenium `IWebElement`. Returns an `AxeResult` representing the scan results.
+
+Not compatible with `AxeBuilder.Include` or `AxeBuilder.Exclude`; the element passed to `Analyze` will take precedence and the `Include`/`Exclude` calls will be ignored.
+
+### `AxeBuilder.Include(params string[] cssSelectorPath)`
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .Include(".class-of-element-under-test")
+    .Analyze();
+```
+
+Scopes future `Analyze()` calls to include *only* the element(s) matching the given CSS selector.
+
+`Include` may be chained multiple times to include multiple selectors in a scan.
+
+`Include` may be combined with `Exclude` to scan a tree of elements but omit some children of that tree. For example:
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .Include("#element-under-test")
+    .Exclude("#element-under-test div.child-class-with-known-issues")
+    .Analyze();
+```
+
+`Include` is not compatible with `Analyze(IWebElement)` - the `Analyze` argument will take precedence and `Include` will be ignored.
+
+If you pass multiple CSS selectors to a single invocation of `Include`, this will be interpreted as being a path through different `<iframe>`s on the page under test, **not** as multiple elements:
+
+```csharp
+// This is correct
+var results = new AxeBuilder(webDriver)
+    .Include("#id-of-iframe", "#id-of-child-element-inside-iframe")
+    .Analyze();
+
+// This is wrong!
+var results = new AxeBuilder(webDriver)
+    .Include("#first-element", "#second-element")
+    .Analyze();
+
+// If you want to include multiple elements, use multiple .Include() calls instead
+var results = new AxeBuilder(webDriver)
+    .Include("#first-element")
+    .Include("#second-element")
+    .Analyze();
+```
+
+### `AxeBuilder.Exclude(params string[] cssSelectorPath)`
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .Exclude(".class-of-element-with-known-issues")
+    .Analyze();
+```
+
+Scopes future `Analyze()` calls to exclude the element(s) matching the given CSS selector.
+
+`Exclude` may be chained multiple times to exclude multiple selectors in a scan.
+
+`Exclude` may be combined with `Include` to scan a tree of elements but omit some children of that tree. For example:
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .Include("#element-under-test")
+    .Exclude("#element-under-test div.child-class-with-known-issues")
+    .Analyze();
+```
+
+`Exclude` is not compatible with `Analyze(IWebElement)` - the `Analyze` argument will take precedence and `Exclude` will be ignored.
+
+If you pass multiple CSS selectors to a single invocation of `Exclude`, this will be interpreted as being a path through different `<iframe>`s on the page under test, **not** as multiple elements:
+
+```csharp
+// This is correct
+var results = new AxeBuilder(webDriver)
+    .Exclude("#id-of-iframe", "#id-of-child-element-inside-iframe")
+    .Analyze();
+
+// This is wrong!
+var results = new AxeBuilder(webDriver)
+    .Exclude("#first-element", "#second-element")
+    .Analyze();
+
+// If you want to exclude multiple elements, use multiple .Exclude() calls instead
+var results = new AxeBuilder(webDriver)
+    .Exclude("#first-element")
+    .Exclude("#second-element")
+    .Analyze();
+```
+
+### `AxeBuilder.WithRules(params string[] axeRuleIds)`
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .WithRules("color-contrast", "duplicate-id")
+    .Analyze();
+```
+
+Causes future calls to `Analyze` to only run the specified axe rules.
+
+For a list of the available axe rules, see https://dequeuniversity.com/rules/axe/3.3. The "Rule ID" at the top of each individual rule's page is the ID you would want to pass to this method.
+
+`WithRules` is not compatible with `WithTags` or `DisableRules`; whichever one you specify last will take precedence.
+
+`WithRules` is not compatible with the deprecated raw `Options` property.
+
+### `AxeBuilder.DisableRules(params string[] axeRuleIds)`
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .DisableRules("color-contrast", "duplicate-id")
+    .Analyze();
+```
+
+Causes future calls to `Analyze` to omit the specified axe rules.
+
+For a list of the available axe rules, see https://dequeuniversity.com/rules/axe/3.3. The "Rule ID" at the top of each individual rule's page is the ID you would want to pass to this method.
+
+`DisableRules` is compatible with `WithTags`; you can use this to run all-but-some of the rules for a given set of tags. For example, to run all WCAG 2.0 A rules except for `color-contrast`:
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .WithTags("wcag2a")
+    .DisableRules("color-contrast")
+    .Analyze();
+```
+
+`DisableRules` is not compatible with `WithRules`; whichever one you specify second will take precedence.
+
+`DisableRules` is not compatible with the deprecated raw `Options` property.
+
+### `AxeBuilder.WithTags(params string[] axeRuleTags)`
+
+Causes future calls to `Analyze` to only run axe rules that match at least one of the specified tags.
+
+A "tag" is a string that may be associated with a given axe rule. See the [axe-core API documentation](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter) for a complete list of available tags.
+
+`WithTags` is compatible with `DisableRules`; you can use this to run all-but-some of the rules for a given set of tags. For example, to run all WCAG 2.0 A rules except for `color-contrast`:
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .WithTags("wcag2a")
+    .DisableRules("color-contrast")
+    .Analyze();
+```
+
+`WithTags` is not compatible with `WithRules`; whichever one you specify second will take precedence.
+
+`WithTags` is not compatible with the deprecated raw `Options` property.
+
+### `AxeBuilder.WithOptions(AxeRunOptions options)`
+
+*Note: in most cases, the simpler `WithRules`, `WithTags`, and `DisableRules` can be used instead.*
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .WithOptions(new AxeRunOptions()
     {
-        ScriptProvider = new FileAxeScriptProvider(".\\axe.min.js")
-    };
-    var results = new AxeBuilder(webDriver, axeBuilderOptions)
-                        .Analyze();
-    ``` 
+        RunOnly = new RunOnlyOptions
+        {
+            Type = "rule",
+            Values = new List<string> { "duplicate-id", "color-contrast" }
+        },
+        RestoreScroll = true
+    })
+    .Analyze();
+```
 
-Validating scan results:
--   If you start with no accessibility issues in your page, you can stay clean by validating that the Violations list is empty.
+Causes future calls to `Analyze` to use the specified options when calling `axe.run` in axe-core. See [the axe-core API documentation](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter) for descriptions of the different properties of `AxeRunOptions`.
+
+`WithOptions` will override any values previously set by `WithRules`, `WithTags`, and `DisableRules`.
+
+`WithOptions` is not compatible with the deprecated raw `Options` property.
+
+### `AxeBuilder.WithOutputFile(string filePath)`
+
+```csharp
+var results = new AxeBuilder(webDriver)
+    .WithOutputFile(@"./path/to/axe-results.json")
+    .Analyze();
+```
+
+Causes future calls to `Analyze` to export their results to a JSON file, *in addition* to being returned as an `AxeResult` object as usual.
+
+The output format is exactly the same as axe-core would have produced natively, and is compatible with other tools that read axe result JSON, like [axe-sarif-converter](https://github.com/microsoft/axe-sarif-converter).
+
+### `AxeBuilder.AxeBuilder(webDriver, axeBuilderOptions)`
+
+This constructor overload enables certain advanced options not required by most `Selenium.Axe` users. Currently, its only use is to allow you to use a custom `axe-core` implementation, rather than the one that is packaged with this library.
+
+```csharp
+var axeBuilderOptions = new AxeBuilderOptions
+{
+    ScriptProvider = new FileAxeScriptProvider(".\\axe.min.js")
+};
+var results = new AxeBuilder(webDriver, axeBuilderOptions).Analyze();
+```
+
+### *Deprecated*: `AxeBuilder.Options`
+
+*This property is deprecated; instead, use `WithOptions`, `WithRules`, `WithTags`, and `DisableRules`*
+
+```csharp
+var axeBuilder = new AxeBuilder(webDriver);
+axeBuilder.Options = "{\"runOnly\": {\"type\": \"tag\", \"values\": [\"wcag2a\"]}, \"restoreScroll\": true}"
+var results = axeBuilder.Analyze();
+```
+
+Sets a JSON string that will be passed as-is to the axe.run `options` parameter.
+
+See the [axe-core API documentation](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter) for the format for the JSON string.
+
+`Options` is not compatible with `WithRules`, `WithTags`, `DisableRules`, or `WithOptions`
+
+
+## Working with AxeResult objects
+
+In most cases, you would run an axe scan from within a test method in a suite of end to end tests, and you would want to use a test assertion to verify that there are no unexpected accessibility violations in a page or component.
+
+We strongly recommend [FluentAssertions](https://fluentassertions.com/), a NuGet package that does a good job of producing actionable error messages based on the `AxeResult` output from a scan. That said, if you prefer a different assertion library, you can still use this library; it does not require any particular test or assertion framework.
+
+If you start with no accessibility issues in your page, you can stay clean by validating that the Violations list is empty:
+
 ```csharp
 IWebDriver webDriver = new ChromeDriver();
-
 AxeResult results = webDriver.Analyze();
 
 results.Violations.Should().BeEmpty();
 ```
-- If you already have some accessibility issues & you want to make sure that you do not introduce any more new issues till you get to a clean state, you can do snapshot testing / validate by issues count.
+
+If you already have some accessibility issues & you want to make sure that you do not introduce any more new issues till you get to a clean state, you can use `Exclude` to remove problematic elements from a broad scan, and a combination of `Include` and `DisableRules` to perform a more scoped scan of the element with known issues:
+
 ```csharp
-IWebDriver webDriver = new ChromeDriver();
+// Suppose #element-with-contrast-issue has known violations of the color-contrast rule.
 
-AxeResult results = webDriver.Analyze();
+// You could scan that element with the color-contrast rule disabled...
+new AxeBuilder(webDriver)
+    .Include("#element-with-contrast-issue")
+    .DisableRules("color-contrast")
+    .Analyze()
+    .Violations.Should().BeEmpty();
 
-results.Violations.Should().HaveCount(2);
+// ...and then also scan the rest of the page with all rules enabled.
+new AxeBuilder(webDriver)
+    .Exclude("#element-with-contrast-issue")
+    .Analyze()
+    .Violations.Should().BeEmpty();
 ```
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ If you start with no accessibility issues in your page, you can stay clean by va
 
 ```csharp
 IWebDriver webDriver = new ChromeDriver();
-AxeResult results = webDriver.Analyze();
+AxeResult results = new AxeBuilder(webDriver).Analyze();
 
 results.Violations.Should().BeEmpty();
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Compatible with .NET Standard 2.0+, .NET Framework 4.5+, and .NET Core 2.0+.
 
 Inspired by [axe-selenium-java](https://github.com/dequelabs/axe-selenium-java) and [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs). Forked from [Globant.Selenium.Axe](https://github.com/javnov/axe-selenium-csharp).
 
+## Table of Contents
+
 * [Getting Started](#Getting_Started)
 * [`AxeBuilder` Reference](#AxeBuilder_Reference)
 * [Working with `AxeResult` objects](#Working_with_AxeResult_objects)
@@ -44,7 +46,7 @@ using FluentAssertions;
 axeResult.Violations.Should().BeEmpty();
 ```
 
-To configure different scan options, use the chainable methods of the `AxeBuilder` ([reference docs](#AxeBuilder_Options)):
+To configure different scan options, use the chainable methods of the `AxeBuilder` ([reference docs](#AxeBuilder_Reference)):
 
 ```csharp
 AxeResult axeResult = new AxeBuilder(webDriver)
@@ -55,7 +57,7 @@ AxeResult axeResult = new AxeBuilder(webDriver)
 
 For a complete working sample project that uses this library, see [the C# sample in microsoft/axe-pipelines-samples](https://github.com/microsoft/axe-pipelines-samples/tree/master/csharp-selenium-webdriver-sample).
 
-## AxeBuilder reference
+## AxeBuilder Reference
 
 ### `AxeBuilder.Analyze()`
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,6 @@ See the [axe-core API documentation](https://github.com/dequelabs/axe-core/blob/
 
 `Options` is not compatible with `WithRules`, `WithTags`, `DisableRules`, or `WithOptions`
 
-
 ## Working with AxeResult objects
 
 In most cases, you would run an axe scan from within a test method in a suite of end to end tests, and you would want to use a test assertion to verify that there are no unexpected accessibility violations in a page or component.


### PR DESCRIPTION
Our team recently ran some user studies where we asked a few users to try to integrate this library based on its documentation and [our sample using it](https://github.com/microsoft/axe-pipelines-samples/tree/master/csharp-selenium-webdriver-sample) while letting us watch and hear their thought process. Overall, they found the library's API easy to understand, but a few hit some stumbling blocks in documentation. This PR addresses the portions of their feedback related to this repo's documentation:

* Adds "for .NET" to the title to improve distinguishability from similar packages in search results
* Ensures title is the first line of the readme, again to improve formatting of the page as it will appear in search results
* Clarifies early in the README which versions of .NET it's compatible with
* Clarifies in the "install via nuget" part of Getting Started that you can also use the Visual Studio UI for installing it, not just the package manager command
* Avoids confusion around `webDriver.Analyze()` vs `new AxeBuilder(webDriver).Analyze()` by standardizing the Getting Started suggestions to all be based on one form of the API.
* Suggests the use of FluentAssertions more explicitly
* References a full sample project from within Getting Started
* Make the API reference docs more verbose about compatibility with other methods
* Add more clarifying code examples to reference docs, especially around the multi-parameter formatting of Include/Exclude
* Clarify more explicitly what "rules" and "tags" are and where to find documentation about them
* Format the reference docs more consistently
* Enable anchor links to individual methods' reference docs
* Add a table of contents
* Add more detailed information about how to do baselining of existing failures

I also added a reference from the Contributing section to the new Code of Conduct while I was here