### PR TITLE
Update to Axe core 4.0.1, Configure dependabot to stay current

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,18 @@
+version: 1
+update_configs:
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'daily'
+    version_requirement_updates: 'increase_versions'
+    default_labels:
+      - 'dependencies'
+    commit_message:
+      prefix: 'chore'
+                
+  - package_manager: 'dotnet:nuget'
+    directory: '/'
+    update_schedule: 'daily'
+    default_labels:
+      - 'dependencies'
+    commit_message:
+      prefix: 'chore'

--- a/Selenium.Axe/Selenium.Axe/package-lock.json
+++ b/Selenium.Axe/Selenium.Axe/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "axe-core": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.3.tgz",
-      "integrity": "sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.1.tgz",
+      "integrity": "sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw=="
     }
   }
 }

--- a/Selenium.Axe/Selenium.Axe/package.json
+++ b/Selenium.Axe/Selenium.Axe/package.json
@@ -3,6 +3,6 @@
   "repository": {},
   "license": "MIT",
   "dependencies": {
-    "axe-core": "^3.5.3"
+    "axe-core": "4.0.1"
   }
 }

--- a/Selenium.Axe/Selenium.Axe/package.json
+++ b/Selenium.Axe/Selenium.Axe/package.json
@@ -3,6 +3,6 @@
   "repository": {},
   "license": "MIT",
   "dependencies": {
-    "axe-core": "4.0.1"
+    "axe-core": "^4.0.1"
   }
 }


### PR DESCRIPTION
Deque recently released [axe-core 4.0.1](https://www.npmjs.com/package/axe-core/v/4.0.1). This PR picks up that change and configures dependabot to keep the libraries current. Happy to split this into 2 PRs, if desired.