### PR TITLE
Select Result Type to be in the Html Report

### DIFF
--- a/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
@@ -85,7 +85,7 @@ namespace Selenium.Axe.Test
             InitDriver(browser);
             LoadSimpleTestPage();
 
-            var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
+            _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
 
             _webDriver.CreateAxeHtmlReport(path);
 
@@ -101,12 +101,12 @@ namespace Selenium.Axe.Test
             InitDriver(browser);
             LoadSimpleTestPage();
 
-            var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
+            _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
 
-            _webDriver.CreateAxeHtmlReport(path, ReportType.Violations);
+            _webDriver.CreateAxeHtmlReport(path, ReportTypes.Violations);
 
             ValidateReport(path, 4, 0);
-            ValidateResultNotWritten(path, ReportType.Passes | ReportType.Incomplete | ReportType.Inapplicable);
+            ValidateResultNotWritten(path, ReportTypes.Passes | ReportTypes.Incomplete | ReportTypes.Inapplicable);
         }
 
         [TestMethod]
@@ -118,11 +118,11 @@ namespace Selenium.Axe.Test
             InitDriver(browser);
             LoadSimpleTestPage();
 
-            var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
-            _webDriver.CreateAxeHtmlReport(path, ReportType.Passes | ReportType.Inapplicable | ReportType.Violations);
+            _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
+            _webDriver.CreateAxeHtmlReport(path, ReportTypes.Passes | ReportTypes.Inapplicable | ReportTypes.Violations);
 
             ValidateReport(path, 4, 28, 0, 63);
-            ValidateResultNotWritten(path, ReportType.Incomplete);
+            ValidateResultNotWritten(path, ReportTypes.Incomplete);
         }
 
         [TestMethod]
@@ -166,7 +166,7 @@ namespace Selenium.Axe.Test
             string path = CreateReportPath();
             InitDriver(browser);
             LoadSimpleTestPage();
-            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector(mainElementSelector)));
+            _wait.Until(drv => drv.FindElement(By.CssSelector(mainElementSelector)));
 
             var builder = new AxeBuilder(_webDriver).DisableRules("color-contrast");
             _webDriver.CreateAxeHtmlReport(builder.Analyze(), path);
@@ -182,7 +182,7 @@ namespace Selenium.Axe.Test
             string path = CreateReportPath();
             InitDriver(browser);
             LoadSimpleTestPage();
-            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector(mainElementSelector)));
+            _wait.Until(drv => drv.FindElement(By.CssSelector(mainElementSelector)));
             JObject jResult = JObject.Parse(File.ReadAllText(IntegrationTestJsonResultFile));
             var results = new AxeResult(jResult);
             _webDriver.CreateAxeHtmlReport(results, path);
@@ -227,7 +227,7 @@ namespace Selenium.Axe.Test
                 .Select(x => x.Target.Last())
                 .First();
             Assert.IsNotNull(complexTargetNode);
-            Assert.IsTrue(complexTargetNode.Selectors.Count() == 2);
+            Assert.IsTrue(complexTargetNode.Selectors.Count == 2);
         }
 
         private string CreateReportPath()
@@ -295,7 +295,7 @@ namespace Selenium.Axe.Test
             Assert.IsTrue(text.Contains($"{resultType}: {count}"), $"Expected to find '{resultType}: {count}'");
         }
 
-        private void ValidateResultNotWritten(string path, ReportType ReportType)
+        private void ValidateResultNotWritten(string path, ReportTypes ReportType)
         {
             string text = File.ReadAllText(path);
  

--- a/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
@@ -10,6 +10,7 @@ using OpenQA.Selenium.Support.UI;
 using System;
 using System.IO;
 using System.Linq;
+using static Selenium.Axe.HtmlReport;
 
 namespace Selenium.Axe.Test
 {
@@ -95,33 +96,34 @@ namespace Selenium.Axe.Test
         [TestMethod]
         [DataRow("Chrome")]
         [DataRow("FireFox")]
-        public void ReportFullPageViolationsOnly(String browser)
+        public void ReportFullPageViolationsOnly(string browser)
         {
-            String path = CreateReportPath();
+            string path = CreateReportPath();
             InitDriver(browser);
             LoadSimpleTestPage();
 
             var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
-            _webDriver.CreateAxeHtmlReport(path, new ResultType[] { ResultType.Violations });
+
+            _webDriver.CreateAxeHtmlReport(path, ReportTypes.Violations);
 
             ValidateReport(path, 4, 0);
-            ValidateResultNotWritten(path, new ResultType[] { ResultType.Passes, ResultType.Incomplete, ResultType.Inapplicable });
+            ValidateResultNotWritten(path, ReportTypes.Passes | ReportTypes.Incomplete | ReportTypes.Inapplicable);
         }
 
         [TestMethod]
         [DataRow("Chrome")]
         [DataRow("FireFox")]
-        public void ReportFullPageOnlyPassesInapplicableViolations(string browser)
+        public void ReportFullPagePassesInapplicableViolationsOnly(string browser)
         {
-            String path = CreateReportPath();
+            string path = CreateReportPath();
             InitDriver(browser);
             LoadSimpleTestPage();
 
             var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
-            _webDriver.CreateAxeHtmlReport(path, new ResultType[] { ResultType.Passes, ResultType.Inapplicable, ResultType.Violations });
+            _webDriver.CreateAxeHtmlReport(path, ReportTypes.Passes | ReportTypes.Inapplicable | ReportTypes.Violations);
 
             ValidateReport(path, 4, 28, 0, 63);
-            ValidateResultNotWritten(path, new ResultType[] { ResultType.Incomplete});
+            ValidateResultNotWritten(path, ReportTypes.Incomplete);
         }
 
         [TestMethod]
@@ -284,23 +286,24 @@ namespace Selenium.Axe.Test
                 ValidateResultCount(text, incompleteCount, ResultType.Incomplete);
             }
         }
-        private void ValidateElementCount(HtmlDocument doc, int count, String xpath, ResultType resultType)
+
+        private void ValidateElementCount(HtmlDocument doc, int count, string xpath, ResultType resultType)
         {
             HtmlNodeCollection liNodes = doc.DocumentNode.SelectNodes(xpath) ?? new HtmlNodeCollection(null);
             Assert.AreEqual(liNodes.Count, count, $"Expected {count} {resultType}");
         }
-
 
         private void ValidateResultCount(string text, int count, ResultType resultType)
         {
             Assert.IsTrue(text.Contains($"{resultType}: {count}"), $"Expected to find '{resultType}: {count}'");
         }
 
-        private void ValidateResultNotWritten(string path, ResultType[] resultTypeArray)
+        private void ValidateResultNotWritten(string path, ReportTypes reportTypes)
         {
             string text = File.ReadAllText(path);
-        
-            foreach (ResultType resultType in resultTypeArray)
+            //string[] reportTypeList = ; 
+ 
+            foreach (string resultType in reportTypes.ToString().Split(','))
             {
                 Assert.IsFalse(text.Contains($"{resultType}: "), $"Expected to not find '{resultType}: '");
             }

--- a/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
@@ -36,7 +36,7 @@ namespace Selenium.Axe.Test
             _webDriver?.Quit();
             _webDriver?.Dispose();
         }
-        
+
         [TestMethod]
         [DataRow("Chrome")]
         [DataRow("Firefox")]
@@ -70,7 +70,7 @@ namespace Selenium.Axe.Test
             InitDriver(browser);
             LoadSimpleTestPage();
 
-            var mainElement = _wait.Until(drv => drv.FindElement(By.TagName("main")));
+            var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
 
             AxeResult results = _webDriver.Analyze(mainElement);
             results.Violations.Should().HaveCount(3);
@@ -85,10 +85,43 @@ namespace Selenium.Axe.Test
             InitDriver(browser);
             LoadSimpleTestPage();
 
-            var mainElement = _wait.Until(drv => drv.FindElement(By.TagName("main")));
+            var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
+
             _webDriver.CreateAxeHtmlReport(path);
 
             ValidateReport(path, 4, 28, 0, 63);
+        }
+
+        [TestMethod]
+        [DataRow("Chrome")]
+        [DataRow("FireFox")]
+        public void ReportFullPageViolationsOnly(String browser)
+        {
+            String path = CreateReportPath();
+            InitDriver(browser);
+            LoadSimpleTestPage();
+
+            var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
+            _webDriver.CreateAxeHtmlReport(path, new ResultType[] { ResultType.Violations });
+
+            ValidateReport(path, 4, 0);
+            ValidateResultNotWritten(path, new ResultType[] { ResultType.Passes, ResultType.Incomplete, ResultType.Inapplicable });
+        }
+
+        [TestMethod]
+        [DataRow("Chrome")]
+        [DataRow("FireFox")]
+        public void ReportFullPageOnlyPassesInapplicableViolations(string browser)
+        {
+            String path = CreateReportPath();
+            InitDriver(browser);
+            LoadSimpleTestPage();
+
+            var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
+            _webDriver.CreateAxeHtmlReport(path, new ResultType[] { ResultType.Passes, ResultType.Inapplicable, ResultType.Violations });
+
+            ValidateReport(path, 4, 28, 0, 63);
+            ValidateResultNotWritten(path, new ResultType[] { ResultType.Incomplete});
         }
 
         [TestMethod]
@@ -100,7 +133,7 @@ namespace Selenium.Axe.Test
             InitDriver(browser);
             LoadSimpleTestPage();
 
-            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector("main")));
+            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector(mainElementSelector)));
             _webDriver.CreateAxeHtmlReport(mainElement, path);
 
             ValidateReport(path, 3, 16, 0, 69);
@@ -114,11 +147,11 @@ namespace Selenium.Axe.Test
             string path = CreateReportPath();
             InitDriver(browser);
             LoadSimpleTestPage();
-            
+
             _webDriver = new EventFiringWebDriver(_webDriver);
             _wait = new WebDriverWait(_webDriver, TimeSpan.FromSeconds(20));
 
-            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector("main")));
+            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector(mainElementSelector)));
             _webDriver.CreateAxeHtmlReport(mainElement, path);
 
             ValidateReport(path, 3, 16, 0, 69);
@@ -132,7 +165,7 @@ namespace Selenium.Axe.Test
             string path = CreateReportPath();
             InitDriver(browser);
             LoadSimpleTestPage();
-            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector("main")));
+            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector(mainElementSelector)));
 
             var builder = new AxeBuilder(_webDriver).DisableRules("color-contrast");
             _webDriver.CreateAxeHtmlReport(builder.Analyze(), path);
@@ -148,7 +181,7 @@ namespace Selenium.Axe.Test
             string path = CreateReportPath();
             InitDriver(browser);
             LoadSimpleTestPage();
-            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector("main")));
+            var mainElement = _wait.Until(drv => drv.FindElement(By.CssSelector(mainElementSelector)));
             JObject jResult = JObject.Parse(File.ReadAllText(IntegrationTestJsonResultFile));
             var results = new AxeResult(jResult);
             _webDriver.CreateAxeHtmlReport(results, path);
@@ -181,11 +214,11 @@ namespace Selenium.Axe.Test
             var axeResult = new AxeBuilder(_webDriver)
                 .WithOutputFile(@".\raw-axe-results.json")
                 .Analyze();
-            
+
             var colorContrast = axeResult
                 .Violations
                 .FirstOrDefault(x => x.Id == "color-contrast");
-            
+
             Assert.IsNotNull(colorContrast);
             var complexTargetNode = colorContrast
                 .Nodes
@@ -204,6 +237,8 @@ namespace Selenium.Axe.Test
             return Path.Combine(Path.GetDirectoryName(path), Guid.NewGuid() + ".html");
         }
 
+       
+
         private void ValidateReport(string path, int violationCount, int passCount, int incompleteCount = 0, int inapplicableCount = 0)
         {
             string text = File.ReadAllText(path);
@@ -212,30 +247,63 @@ namespace Selenium.Axe.Test
 
             // Check violations 
             string xpath = ".//*[@id=\"ViolationsSection\"]//*[contains(concat(\" \",normalize-space(@class),\" \"),\"htmlTable\")]";
-            HtmlNodeCollection liNodes = doc.DocumentNode.SelectNodes(xpath) ?? new HtmlNodeCollection(null);
-            Assert.AreEqual(violationCount, liNodes.Count, $"Expected {violationCount} violations");
+            ValidateElementCount(doc, violationCount, xpath, ResultType.Violations);
 
             // Check passes
             xpath = ".//*[@id=\"PassesSection\"]//*[contains(concat(\" \",normalize-space(@class),\" \"),\"htmlTable\")]";
-            liNodes = doc.DocumentNode.SelectNodes(xpath) ?? new HtmlNodeCollection(null);
-            Assert.AreEqual(passCount, liNodes.Count, $"Expected {passCount} passess");
+            ValidateElementCount(doc, passCount, xpath, ResultType.Passes);
 
             // Check inapplicables
             xpath = ".//*[@id=\"InapplicableSection\"]//*[contains(concat(\" \",normalize-space(@class),\" \"),\"findings\")]";
-            liNodes = doc.DocumentNode.SelectNodes(xpath) ?? new HtmlNodeCollection(null);
-            Assert.AreEqual(inapplicableCount, liNodes.Count, $"Expected {inapplicableCount} inapplicables");
+            ValidateElementCount(doc, inapplicableCount, xpath, ResultType.Inapplicable);
 
             // Check incompletes
             xpath = ".//*[@id=\"IncompleteSection\"]//*[contains(concat(\" \",normalize-space(@class),\" \"),\"htmlTable\")]";
-            liNodes = doc.DocumentNode.SelectNodes(xpath) ?? new HtmlNodeCollection(null);
-            Assert.AreEqual(incompleteCount, liNodes.Count, $"Expected {incompleteCount} incompletes");
+            ValidateElementCount(doc, incompleteCount, xpath, ResultType.Incomplete);
 
             // Check header data
             Assert.IsTrue(text.Contains("Using: axe-core"), "Expected to find 'Using: axe-core'");
-            Assert.IsTrue(text.Contains($"Violation: {violationCount}"), $"Expected to find 'Violation: {violationCount}'");
-            Assert.IsTrue(text.Contains($"Incomplete: {incompleteCount}"), $"Expected to find 'Incomplete: {incompleteCount}'");
-            Assert.IsTrue(text.Contains($"Pass: {passCount}"), $"Expected to find 'Pass: {passCount}'");
-            Assert.IsTrue(text.Contains($"Inapplicable: {inapplicableCount}"), $"Expected to find 'Inapplicable: {inapplicableCount}'");
+
+            if (!violationCount.Equals(0))
+            {
+                ValidateResultCount(text, violationCount, ResultType.Violations);
+            }
+
+            if (!passCount.Equals(0))
+            {
+                ValidateResultCount(text, passCount, ResultType.Passes);
+            }
+
+            if (!inapplicableCount.Equals(0))
+            {
+                ValidateResultCount(text, inapplicableCount, ResultType.Inapplicable);
+            }
+
+            if (!incompleteCount.Equals(0))
+            {
+                ValidateResultCount(text, incompleteCount, ResultType.Incomplete);
+            }
+        }
+        private void ValidateElementCount(HtmlDocument doc, int count, String xpath, ResultType resultType)
+        {
+            HtmlNodeCollection liNodes = doc.DocumentNode.SelectNodes(xpath) ?? new HtmlNodeCollection(null);
+            Assert.AreEqual(liNodes.Count, count, $"Expected {count} {resultType}");
+        }
+
+
+        private void ValidateResultCount(string text, int count, ResultType resultType)
+        {
+            Assert.IsTrue(text.Contains($"{resultType}: {count}"), $"Expected to find '{resultType}: {count}'");
+        }
+
+        private void ValidateResultNotWritten(string path, ResultType[] resultTypeArray)
+        {
+            string text = File.ReadAllText(path);
+        
+            foreach (ResultType resultType in resultTypeArray)
+            {
+                Assert.IsFalse(text.Contains($"{resultType}: "), $"Expected to not find '{resultType}: '");
+            }
         }
 
         private void LoadSimpleTestPage()

--- a/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
+++ b/Selenium.Axe/Selenium.Axe.Test/IntegrationTests.cs
@@ -10,7 +10,6 @@ using OpenQA.Selenium.Support.UI;
 using System;
 using System.IO;
 using System.Linq;
-using static Selenium.Axe.HtmlReport;
 
 namespace Selenium.Axe.Test
 {
@@ -104,10 +103,10 @@ namespace Selenium.Axe.Test
 
             var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
 
-            _webDriver.CreateAxeHtmlReport(path, ReportTypes.Violations);
+            _webDriver.CreateAxeHtmlReport(path, ReportType.Violations);
 
             ValidateReport(path, 4, 0);
-            ValidateResultNotWritten(path, ReportTypes.Passes | ReportTypes.Incomplete | ReportTypes.Inapplicable);
+            ValidateResultNotWritten(path, ReportType.Passes | ReportType.Incomplete | ReportType.Inapplicable);
         }
 
         [TestMethod]
@@ -120,10 +119,10 @@ namespace Selenium.Axe.Test
             LoadSimpleTestPage();
 
             var mainElement = _wait.Until(drv => drv.FindElement(By.TagName(mainElementSelector)));
-            _webDriver.CreateAxeHtmlReport(path, ReportTypes.Passes | ReportTypes.Inapplicable | ReportTypes.Violations);
+            _webDriver.CreateAxeHtmlReport(path, ReportType.Passes | ReportType.Inapplicable | ReportType.Violations);
 
             ValidateReport(path, 4, 28, 0, 63);
-            ValidateResultNotWritten(path, ReportTypes.Incomplete);
+            ValidateResultNotWritten(path, ReportType.Incomplete);
         }
 
         [TestMethod]
@@ -238,9 +237,7 @@ namespace Selenium.Axe.Test
             string path = Uri.UnescapeDataString(uri.Path);
             return Path.Combine(Path.GetDirectoryName(path), Guid.NewGuid() + ".html");
         }
-
-       
-
+      
         private void ValidateReport(string path, int violationCount, int passCount, int incompleteCount = 0, int inapplicableCount = 0)
         {
             string text = File.ReadAllText(path);
@@ -298,12 +295,11 @@ namespace Selenium.Axe.Test
             Assert.IsTrue(text.Contains($"{resultType}: {count}"), $"Expected to find '{resultType}: {count}'");
         }
 
-        private void ValidateResultNotWritten(string path, ReportTypes reportTypes)
+        private void ValidateResultNotWritten(string path, ReportType ReportType)
         {
             string text = File.ReadAllText(path);
-            //string[] reportTypeList = ; 
  
-            foreach (string resultType in reportTypes.ToString().Split(','))
+            foreach (string resultType in ReportType.ToString().Split(','))
             {
                 Assert.IsFalse(text.Contains($"{resultType}: "), $"Expected to not find '{resultType}: '");
             }

--- a/Selenium.Axe/Selenium.Axe/HtmlReport.cs
+++ b/Selenium.Axe/Selenium.Axe/HtmlReport.cs
@@ -8,18 +8,21 @@ using System.Web;
 
 namespace Selenium.Axe
 {
+    /// <summary>
+    /// Findings to include in your HTML
+    /// </summary>
+    [Flags]
+    public enum ReportType
+    {
+        Violations = 1,
+        Incomplete = 2,
+        Inapplicable = 4,
+        Passes = 8,
+        All = 15
+    }
+
     public static class HtmlReport
     {
-        [Flags]
-        public enum ReportTypes
-        {
-            Violations = 1,
-            Incomplete = 2,
-            Inapplicable = 4,
-            Passes = 8,
-            All = 15
-        }
-
         private const string js = @"var buttons = document.getElementsByClassName(""sectionbutton"");
                               var i;
                               
@@ -62,25 +65,25 @@ namespace Selenium.Axe
                                  modalimg.alt = thumbnail.alt;
                                })";
 
-        public static void CreateAxeHtmlReport(this IWebDriver webDriver, string destination, ReportTypes requestedResults = ReportTypes.All)
+        public static void CreateAxeHtmlReport(this IWebDriver webDriver, string destination, ReportType requestedResults = ReportType.All)
         {
             var axeBuilder = new AxeBuilder(webDriver);
             webDriver.CreateAxeHtmlReport(axeBuilder.Analyze(), destination, requestedResults);
         }
 
-        public static void CreateAxeHtmlReport(this IWebDriver webDriver, IWebElement context, string destination, ReportTypes requestedResults = ReportTypes.All)
+        public static void CreateAxeHtmlReport(this IWebDriver webDriver, IWebElement context, string destination, ReportType requestedResults = ReportType.All)
         {
             var axeBuilder = new AxeBuilder(webDriver);
             context.CreateAxeHtmlReportFile(axeBuilder.Analyze(context), destination, requestedResults);
         }
         
         
-        public static void CreateAxeHtmlReport(this IWebDriver webdriver, AxeResult results, string destination, ReportTypes requestedResults = ReportTypes.All)
+        public static void CreateAxeHtmlReport(this IWebDriver webdriver, AxeResult results, string destination, ReportType requestedResults = ReportType.All)
         {
             webdriver.CreateAxeHtmlReportFile(results, destination, requestedResults);
         }
         
-        private static void CreateAxeHtmlReportFile(this ISearchContext context, AxeResult results, string destination, ReportTypes requestedResults)
+        private static void CreateAxeHtmlReportFile(this ISearchContext context, AxeResult results, string destination, ReportType requestedResults)
         {
             // Get the unwrapped element if we are using a wrapped element
             context = context is IWrapsElement ? (context as IWrapsElement).WrappedElement : context;
@@ -172,22 +175,22 @@ namespace Selenium.Axe
             }
 
 
-            if (violationCount > 0 && requestedResults.HasFlag(ReportTypes.Violations))
+            if (violationCount > 0 && requestedResults.HasFlag(ReportType.Violations))
             {
                 GetReadableAxeResults(results.Violations, ResultType.Violations.ToString(), doc, resultsFlex);
             }
 
-            if (incompleteCount > 0 && requestedResults.HasFlag(ReportTypes.Incomplete))
+            if (incompleteCount > 0 && requestedResults.HasFlag(ReportType.Incomplete))
             {
                 GetReadableAxeResults(results.Incomplete, ResultType.Incomplete.ToString(), doc, resultsFlex);
             }
 
-            if (passCount > 0 && requestedResults.HasFlag(ReportTypes.Passes))
+            if (passCount > 0 && requestedResults.HasFlag(ReportType.Passes))
             {
                 GetReadableAxeResults(results.Passes, ResultType.Passes.ToString(), doc, resultsFlex);
             }
 
-            if (inapplicableCount > 0 && requestedResults.HasFlag(ReportTypes.Inapplicable))
+            if (inapplicableCount > 0 && requestedResults.HasFlag(ReportType.Inapplicable))
             {
                 GetReadableAxeResults(results.Inapplicable, ResultType.Inapplicable.ToString(), doc, resultsFlex);
             }
@@ -297,25 +300,25 @@ namespace Selenium.Axe
             return count;
         }
 
-        private static string GetCountContent(int violationCount, int incompleteCount, int passCount, int inapplicableCount, ReportTypes requestedResults) {
+        private static string GetCountContent(int violationCount, int incompleteCount, int passCount, int inapplicableCount, ReportType requestedResults) {
             StringBuilder countString = new StringBuilder();
 
-            if (requestedResults.HasFlag(ReportTypes.Violations))
+            if (requestedResults.HasFlag(ReportType.Violations))
             {
                 countString.AppendLine($" Violation: {violationCount}<br>");
             }
             
-            if (requestedResults.HasFlag(ReportTypes.Incomplete))
+            if (requestedResults.HasFlag(ReportType.Incomplete))
             {
                 countString.AppendLine($" Incomplete: {incompleteCount}<br>");
             }
             
-            if (requestedResults.HasFlag(ReportTypes.Passes))
+            if (requestedResults.HasFlag(ReportType.Passes))
             {
                 countString.AppendLine($" Pass: {passCount}<br>");
             }
             
-            if (requestedResults.HasFlag(ReportTypes.Inapplicable))
+            if (requestedResults.HasFlag(ReportType.Inapplicable))
             {
                 countString.AppendLine($" Inapplicable: {inapplicableCount}");
             }

--- a/Selenium.Axe/Selenium.Axe/HtmlReport.cs
+++ b/Selenium.Axe/Selenium.Axe/HtmlReport.cs
@@ -323,18 +323,6 @@ namespace Selenium.Axe
             return countString.ToString();
         }
 
-        private static string ReportResultsToString(ResultType[] requestedResults)
-        {
-            StringBuilder stringBuilder = new StringBuilder();
-
-            foreach (ResultType reportType in requestedResults)
-            {
-                stringBuilder.AppendLine(reportType.ToString());
-            }
-
-            return stringBuilder.ToString();
-        }
-
         private static void GetReadableAxeResults(AxeResultItem[] results, string type, HtmlDocument doc, HtmlNode body)
         {
             var selectors = new HashSet<string>();

--- a/Selenium.Axe/Selenium.Axe/HtmlReport.cs
+++ b/Selenium.Axe/Selenium.Axe/HtmlReport.cs
@@ -12,7 +12,7 @@ namespace Selenium.Axe
     /// Findings to include in your HTML
     /// </summary>
     [Flags]
-    public enum ReportType
+    public enum ReportTypes
     {
         Violations = 1,
         Incomplete = 2,
@@ -65,25 +65,25 @@ namespace Selenium.Axe
                                  modalimg.alt = thumbnail.alt;
                                })";
 
-        public static void CreateAxeHtmlReport(this IWebDriver webDriver, string destination, ReportType requestedResults = ReportType.All)
+        public static void CreateAxeHtmlReport(this IWebDriver webDriver, string destination, ReportTypes requestedResults = ReportTypes.All)
         {
             var axeBuilder = new AxeBuilder(webDriver);
             webDriver.CreateAxeHtmlReport(axeBuilder.Analyze(), destination, requestedResults);
         }
 
-        public static void CreateAxeHtmlReport(this IWebDriver webDriver, IWebElement context, string destination, ReportType requestedResults = ReportType.All)
+        public static void CreateAxeHtmlReport(this IWebDriver webDriver, IWebElement context, string destination, ReportTypes requestedResults = ReportTypes.All)
         {
             var axeBuilder = new AxeBuilder(webDriver);
             context.CreateAxeHtmlReportFile(axeBuilder.Analyze(context), destination, requestedResults);
         }
         
         
-        public static void CreateAxeHtmlReport(this IWebDriver webdriver, AxeResult results, string destination, ReportType requestedResults = ReportType.All)
+        public static void CreateAxeHtmlReport(this IWebDriver webdriver, AxeResult results, string destination, ReportTypes requestedResults = ReportTypes.All)
         {
             webdriver.CreateAxeHtmlReportFile(results, destination, requestedResults);
         }
         
-        private static void CreateAxeHtmlReportFile(this ISearchContext context, AxeResult results, string destination, ReportType requestedResults)
+        private static void CreateAxeHtmlReportFile(this ISearchContext context, AxeResult results, string destination, ReportTypes requestedResults)
         {
             // Get the unwrapped element if we are using a wrapped element
             context = context is IWrapsElement ? (context as IWrapsElement).WrappedElement : context;
@@ -175,22 +175,22 @@ namespace Selenium.Axe
             }
 
 
-            if (violationCount > 0 && requestedResults.HasFlag(ReportType.Violations))
+            if (violationCount > 0 && requestedResults.HasFlag(ReportTypes.Violations))
             {
                 GetReadableAxeResults(results.Violations, ResultType.Violations.ToString(), doc, resultsFlex);
             }
 
-            if (incompleteCount > 0 && requestedResults.HasFlag(ReportType.Incomplete))
+            if (incompleteCount > 0 && requestedResults.HasFlag(ReportTypes.Incomplete))
             {
                 GetReadableAxeResults(results.Incomplete, ResultType.Incomplete.ToString(), doc, resultsFlex);
             }
 
-            if (passCount > 0 && requestedResults.HasFlag(ReportType.Passes))
+            if (passCount > 0 && requestedResults.HasFlag(ReportTypes.Passes))
             {
                 GetReadableAxeResults(results.Passes, ResultType.Passes.ToString(), doc, resultsFlex);
             }
 
-            if (inapplicableCount > 0 && requestedResults.HasFlag(ReportType.Inapplicable))
+            if (inapplicableCount > 0 && requestedResults.HasFlag(ReportTypes.Inapplicable))
             {
                 GetReadableAxeResults(results.Inapplicable, ResultType.Inapplicable.ToString(), doc, resultsFlex);
             }
@@ -300,25 +300,25 @@ namespace Selenium.Axe
             return count;
         }
 
-        private static string GetCountContent(int violationCount, int incompleteCount, int passCount, int inapplicableCount, ReportType requestedResults) {
+        private static string GetCountContent(int violationCount, int incompleteCount, int passCount, int inapplicableCount, ReportTypes requestedResults) {
             StringBuilder countString = new StringBuilder();
 
-            if (requestedResults.HasFlag(ReportType.Violations))
+            if (requestedResults.HasFlag(ReportTypes.Violations))
             {
                 countString.AppendLine($" Violation: {violationCount}<br>");
             }
             
-            if (requestedResults.HasFlag(ReportType.Incomplete))
+            if (requestedResults.HasFlag(ReportTypes.Incomplete))
             {
                 countString.AppendLine($" Incomplete: {incompleteCount}<br>");
             }
             
-            if (requestedResults.HasFlag(ReportType.Passes))
+            if (requestedResults.HasFlag(ReportTypes.Passes))
             {
                 countString.AppendLine($" Pass: {passCount}<br>");
             }
             
-            if (requestedResults.HasFlag(ReportType.Inapplicable))
+            if (requestedResults.HasFlag(ReportTypes.Inapplicable))
             {
                 countString.AppendLine($" Inapplicable: {inapplicableCount}");
             }

--- a/Selenium.Axe/Selenium.Axe/HtmlReport.cs
+++ b/Selenium.Axe/Selenium.Axe/HtmlReport.cs
@@ -329,7 +329,7 @@ namespace Selenium.Axe
             return countString.ToString();
         }
 
-        private static String ReportResultsToString(ResultType[] requestedResults)
+        private static string ReportResultsToString(ResultType[] requestedResults)
         {
             StringBuilder stringBuilder = new StringBuilder();
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -349,6 +349,17 @@ var builder = new AxeBuilder(webDriver).DisableRules("color-contrast");
 webDriver.CreateAxeHtmlReport(builder.Analyze(), path);
 ```
 
+Report with only violations and passes:
+
+```csharp
+IWebDriver webDriver = new ChromeDriver();
+// Navigate to page
+AxeResult results = new AxeBuilder(webDriver).Analyze();
+string path = Path.Combine(GetDestFolder(), "AxeReport.html");
+```
+
+webDriver.CreateAxeHtmlReport(path, ReportTypes.Violations | ReportTypes.Passes);
+
 ## Contributing
 
 *Please note that this project is released with a [Contributor Code of Conduct](https://github.com/TroyWalshProf/SeleniumAxeDotnet/blob/master/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.*


### PR DESCRIPTION
HTML Report:
Created ability to select from the four types of ResultTypes.
Added methods to take in an array of ResultTypes[]
Added methods when not inputting an array of ResultTypes[] to select all four result types

Integration Test:
In integration test, changed the methods used to the newly created methods
Added Only violations test
Added test to select three different types
Added method to test a result type should not be in the report
Simplified assertions to their own methods