### PR TITLE
chore: prevent dependabot updates to FluentAssertions >=6.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
   labels:
   - dependencies
   commit-message:
+  ignore:
+    # FluentAssertions v6 dropped support for .NET Framework 4.5, but we want
+    # to maintain support for it at least until Microsoft drops official support,
+    # so we need to pin to FluentAssertions v5 for the time being.
+  - dependency-name: FluentAssertions
+    versions:
+    - ">=6.0.0"
 - package-ecosystem: npm
   directory: "/Selenium.Axe/Selenium.Axe"
   schedule:


### PR DESCRIPTION
FluentAssertions v6 drops support for .NET Framework 4.5, but I expect we probably want to maintain support in the library/tests for it at least until [it hits end-of-support on April 26 2022](https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/). This PR updates our Dependabot config to stick to FluentAssertions v5 until we decide to drop net45 support.

Obsoletes #194.